### PR TITLE
MOD-31: Searching should be more fuzzy

### DIFF
--- a/grails-app/controllers/org/openmrs/modulus/SearchController.groovy
+++ b/grails-app/controllers/org/openmrs/modulus/SearchController.groovy
@@ -15,7 +15,16 @@ class SearchController {
             return
         }
 
-        def search = searchableService.search(cmd.q, cmd),
+        // Create a version of q with wildcard after each word that
+        // is not "and", "or", or within double quotes, for example:
+        // Lorem or ipsum "dolor sit" → Lorem* or ipsum* "dolor sit"
+        // This allows for more natural searches and leaves room for
+        // supporting quotes & conjunctions in future queries.
+        def qWildcards = cmd.q.replaceAll(
+            /(?!and\b|or\b)(\b[^\s]+)\b(?=([^"]*"[^"]*")*[^"]*$)/
+            ){ all, word, dummy -> "$word*" }
+
+        def search = searchableService.search(qWildcards, cmd),
             suggest = searchableService.suggestQuery(cmd.q, [
                     allowSame: false,
                     escape: true


### PR DESCRIPTION
This change adds an asterisk to the end of any word that is not "and", "or", or within double quotes.  The result is that modulus supports partial name searches, while not interfering with support for quoted phrases or simple conjunctions if they are added in the future.
