### PR TITLE
MOD-62: Don't change updated time on downloads

### DIFF
--- a/grails-app/controllers/org/openmrs/modulus/ReleaseController.groovy
+++ b/grails-app/controllers/org/openmrs/modulus/ReleaseController.groovy
@@ -69,8 +69,14 @@ class ReleaseController extends RestfulUploadController {
     def download(Integer id) {
         super.download(id)
         withInstance id, { Release instance ->
+            Release.mapping.autoTimestamp = false
+            Module.mapping.autoTimestamp = false
+
             instance.incrementDownloadCount()
             instance.save()
+
+            Release.mapping.autoTimestamp = true
+            Module.mapping.autoTimestamp = true
         }
     }
 


### PR DESCRIPTION
From [this issue](https://issues.openmrs.org/browse/GCI-26) and [this issue](https://issues.openmrs.org/browse/MOD-62).

This prevents the timestamp from changing when a download occurs.

Bits of me think this is ugly, but Grails' database system doesn't provide a nicer way to do this. 
